### PR TITLE
style(site): polish layout consistency and counts

### DIFF
--- a/scripts/site/build_site.py
+++ b/scripts/site/build_site.py
@@ -620,7 +620,8 @@ def build_index_html(data: dict, domain: str | None) -> str:
         [
             f'<span class="stat-pill">{fmt_int(counts["cataloged_audits"])} audits</span>',
             f'<span class="stat-pill">{fmt_int(counts["normalized_findings"])} findings</span>',
-            f'<span class="stat-pill">{fmt_int(counts["skills_total_with_router"])} skills</span>',
+            f'<span class="stat-pill">{fmt_int(counts["skill_modules"])} modules</span>',
+            '<span class="stat-pill">router</span>',
         ]
     )
 
@@ -632,7 +633,7 @@ def build_index_html(data: dict, domain: str | None) -> str:
             pipeline_step(2, "segment", fmt_int(counts["segmented_audits"]), "segmented corpora"),
             pipeline_step(3, "normalize", fmt_int(counts["normalized_findings"]), "normalized findings"),
             pipeline_step(4, "distill", fmt_int(counts["distilled_vuln_cards"]), "vuln cards"),
-            pipeline_step(5, "skillize", fmt_int(counts["skills_total_with_router"]), "published skills"),
+            pipeline_step(5, "skillize", fmt_int(counts["skill_modules"]), "published modules"),
         ]
     )
 
@@ -713,7 +714,7 @@ def build_index_html(data: dict, domain: str | None) -> str:
       </div>
     </section>
 
-    <section class="section reveal" id="showcase">
+    <section class="section section-card reveal" id="showcase">
       <div class="section-head">
         <div>
           <p class="section-kicker">Example</p>

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -112,7 +112,7 @@ button:focus-visible {
   align-items: center;
   padding: 16px 0;
   backdrop-filter: blur(12px);
-  background: rgba(10, 10, 10, 0.85);
+  background: rgba(10, 10, 10, 0.8);
   border-bottom: 1px solid rgba(42, 42, 42, 0.9);
 }
 
@@ -162,14 +162,14 @@ button:focus-visible {
 .ascii-logo {
   max-width: 100%;
   overflow-x: auto;
-  padding: 20px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--panel);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--accent);
   font-size: 11px;
   line-height: 1.2;
-  box-shadow: var(--shadow);
+  box-shadow: none;
 }
 
 .ascii-logo--small {
@@ -180,7 +180,7 @@ button:focus-visible {
   max-width: 18ch;
   font-size: clamp(2rem, 5vw, 3rem);
   line-height: 1.1;
-  color: var(--text);
+  color: #f2f2f2;
   font-family: "JetBrains Mono", "Fira Code", monospace;
 }
 
@@ -333,6 +333,14 @@ code {
   gap: 24px;
 }
 
+.section-card {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
 .section-head {
   align-items: flex-end;
   gap: 20px;
@@ -464,9 +472,20 @@ code {
   position: absolute;
   top: 34px;
   right: -12px;
-  width: 10px;
+  width: 18px;
   height: 1px;
   background: var(--accent);
+}
+
+.pipeline-step:not(:last-child)::before {
+  content: ">";
+  position: absolute;
+  top: 23px;
+  right: -12px;
+  color: var(--accent);
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.78rem;
+  line-height: 1;
 }
 
 .step-index {
@@ -627,6 +646,10 @@ code {
   .pipeline-step:not(:last-child)::after {
     display: none;
   }
+
+  .pipeline-step:not(:last-child)::before {
+    display: none;
+  }
 }
 
 @media (max-width: 720px) {
@@ -649,7 +672,6 @@ code {
   }
 
   .ascii-logo {
-    padding: 14px;
     font-size: 8px;
   }
 

--- a/website/index.html
+++ b/website/index.html
@@ -46,7 +46,8 @@
       <div class="stats-bar">
         <span class="stat-pill">24 audits</span>
 <span class="stat-pill">217 findings</span>
-<span class="stat-pill">8 skills</span>
+<span class="stat-pill">7 modules</span>
+<span class="stat-pill">router</span>
       </div>
       <div class="hero-install">
         <article class="command-card command-card--primary reveal"><div class="command-head"><div><h2>Raw URL</h2><p>Use the router skill directly.</p></div><button class="copy-button" type="button" data-copy="https://raw.githubusercontent.com/keep-starknet-strange/starknet-skills/main/SKILL.md" aria-label="Copy Raw URL">copy</button></div><pre><code>https://raw.githubusercontent.com/keep-starknet-strange/starknet-skills/main/SKILL.md</code></pre></article>
@@ -59,7 +60,7 @@
       </div>
     </section>
 
-    <section class="section reveal" id="showcase">
+    <section class="section section-card reveal" id="showcase">
       <div class="section-head">
         <div>
           <p class="section-kicker">Example</p>
@@ -114,7 +115,7 @@
 <article class="pipeline-step reveal"><div class="step-index">02</div><h3>segment</h3><div class="step-stat">26</div><p>segmented corpora</p></article>
 <article class="pipeline-step reveal"><div class="step-index">03</div><h3>normalize</h3><div class="step-stat">217</div><p>normalized findings</p></article>
 <article class="pipeline-step reveal"><div class="step-index">04</div><h3>distill</h3><div class="step-stat">3</div><p>vuln cards</p></article>
-<article class="pipeline-step reveal"><div class="step-index">05</div><h3>skillize</h3><div class="step-stat">8</div><p>published skills</p></article>
+<article class="pipeline-step reveal"><div class="step-index">05</div><h3>skillize</h3><div class="step-stat">7</div><p>published modules</p></article>
       </div>
       <p class="section-note">Counts are generated from repo data at build time.</p>
     </section>


### PR DESCRIPTION
## Summary
- remove the boxed treatment around the ASCII logo so it sits directly on the page
- make the hero skill count explicit as `7 modules` plus `router`
- wrap the example section in the same subtle container treatment as the other dense blocks
- strengthen the pipeline connectors and tighten topbar polish

## Validation
- python3 -m py_compile scripts/site/build_site.py
- python3 scripts/site/build_site.py --domain starkskills.org