### PR TITLE
feat(skills): codify contract benchmark findings into skill guidance

### DIFF
--- a/cairo-contract-authoring/SKILL.md
+++ b/cairo-contract-authoring/SKILL.md
@@ -33,6 +33,17 @@ Use this as the entrypoint for implementation decisions; load references only as
 4. Add tests before broadening feature surface.
 5. Run an audit pass with `cairo-auditor`.
 
+## Security-Critical Rules
+
+- Timelock checks must read time from Starknet syscalls (`get_block_timestamp`), never from caller-provided arguments.
+- Every `#[external(v0)]` function that mutates storage must have explicit access posture:
+  - guarded (`assert_only_owner` / role checks), or
+  - intentionally public with a code comment stating why.
+- Upgrade flows must reject zero class hash inputs before applying state transitions.
+- If any of these rules fail in fixture benchmarks, update both:
+  - skill/reference text, and
+  - deterministic cases in `../evals/cases/contract_skill_benchmark.jsonl`.
+
 ## Workflow
 
 - Main authoring flow: [default workflow](workflows/default.md)

--- a/cairo-contract-authoring/references/legacy-full.md
+++ b/cairo-contract-authoring/references/legacy-full.md
@@ -23,6 +23,44 @@ Before finalizing implementation for security-sensitive logic, cross-check:
 - `../../datasets/distilled/fix-patterns/`
 - `../../datasets/distilled/vuln-cards/`
 
+## Upgrade/Auth Hardening Rules
+
+### Timelock Time Source
+
+Never accept `now` as a user argument for timelock checks.
+
+```cairo
+// BAD
+fn execute_upgrade(ref self: ContractState, now: u64) {
+    assert!(now >= self.executable_after.read(), "timelock");
+}
+
+// GOOD
+use starknet::get_block_timestamp;
+
+fn execute_upgrade(ref self: ContractState) {
+    let now = get_block_timestamp();
+    assert!(now >= self.executable_after.read(), "timelock");
+}
+```
+
+### State Mutation Access Posture
+
+For every storage-mutating `#[external(v0)]` function, declare the posture explicitly:
+
+- guarded path (`assert_only_owner` / role check), or
+- intentionally public path with an inline comment justifying public mutability.
+
+Silent implicit posture is not acceptable in security-sensitive modules.
+
+### Non-Zero Upgrade Hash Guard
+
+Reject zero class hash in both schedule and immediate-upgrade flows:
+
+```cairo
+assert!(new_class_hash != 0, "class_hash_zero");
+```
+
 ## Contract Structure
 
 Every Starknet contract follows this skeleton:

--- a/cairo-contract-authoring/workflows/default.md
+++ b/cairo-contract-authoring/workflows/default.md
@@ -15,6 +15,8 @@
 4. Surface hardening
 - Minimize public selectors.
 - Add strict argument validation and auth checks.
+- For timelocked paths, source time from `get_block_timestamp()` only.
+- For upgrade paths, reject zero class hash values.
 
 5. Test-first tightening
 - Add unit tests for nominal/failure paths.
@@ -23,3 +25,7 @@
 6. Security review
 - Run `cairo-auditor` in default mode.
 - Patch findings and add regression tests.
+
+7. Distill findings into skills
+- Encode each fixed class of issue in `../references/legacy-full.md`.
+- Add/adjust deterministic checks in `../../evals/cases/contract_skill_benchmark.jsonl`.

--- a/cairo-optimization/SKILL.md
+++ b/cairo-optimization/SKILL.md
@@ -29,6 +29,7 @@ Apply only after tests pass and behavior is locked.
 2. Profile target paths with `python3 scripts/profile.py profile`.
 3. Apply one optimization class at a time.
 4. Re-run tests and compare resource deltas.
+5. Encode stable optimization rules in `../evals/cases/contract_skill_benchmark.jsonl` to prevent regressions.
 
 ## Workflow
 

--- a/cairo-optimization/references/legacy-full.md
+++ b/cairo-optimization/references/legacy-full.md
@@ -250,6 +250,16 @@ let h = hades_permutation(x, y, 2);
 - **`.tool-versions`:** Pin Scarb and Starknet Foundry versions with ASDF for reproducible builds.
 - **Keep dependencies updated:** Newer Scarb/Foundry versions include gas optimizations and compiler improvements.
 
+### Deterministic Benchmark Rule Authoring
+
+When encoding optimization checks in `evals/cases/contract_skill_benchmark.jsonl`:
+
+- Prefer operation-level patterns over variable names.
+  - Better: `\\bamount\\s*/\\s*2\\b`
+  - Brittle: `let\\s+q\\s*=\\s*amount\\s*/\\s*2\\s*;`
+- Keep each rule tied to one optimization claim (single failure reason).
+- Add paired secure/insecure fixtures so the same rule can pass and fail deterministically.
+
 ---
 
 ## BoundedInt Optimization

--- a/cairo-optimization/workflows/default.md
+++ b/cairo-optimization/workflows/default.md
@@ -17,3 +17,7 @@
 4. Document
 - Record before/after metrics in the PR.
 - Link to the optimization class used from references.
+
+5. Lock the learning
+- Add or update deterministic contract benchmark cases for the optimized pattern.
+- Prefer operation-level static rules (for example, `amount / 2`) over variable-name-coupled patterns.


### PR DESCRIPTION
## Summary
This PR converts recent contract benchmark/review findings into explicit skill guidance so fixes become reusable policy.

## Changes
- Add security-critical contract authoring rules to module entry skill:
  - timelock time source must be syscall-based
  - mutating externals require explicit access posture
  - upgrade flows must reject zero class hash
- Add upgrade/auth hardening examples to contract authoring reference.
- Extend contract authoring workflow with findings-to-skill distillation step.
- Add optimization workflow/rules guidance for deterministic benchmark lock-in and non-brittle static patterns.

## Validation
- `.venv/bin/python scripts/quality/validate_skills.py`
- `.venv/bin/python scripts/quality/parity_check.py`
- `ruff check scripts/quality scripts/site`

All passed locally.
